### PR TITLE
Remove duplicate PLM app entry

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -32,7 +32,7 @@ def _csv_env(name, default=''):
 ALLOWED_HOSTS = _csv_env('DJANGO_ALLOWED_HOSTS', 'localhost,127.0.0.1,[::1]')
 
 INSTALLED_APPS = [
-    'apps.plm.apps.PlmConfig',
+    'apps.plm',
     'widget_tweaks',
     'django.contrib.admin',
     'django.contrib.auth',


### PR DESCRIPTION
## Summary
- reference the PLM app by module path to avoid duplicate registrations during tests

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings pytest -q` *(fails: Model class core.models.DepartmentRole doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_68ad28c9618c8333ae2e9addcfcda4b7