### PR TITLE
Remove debug prints and enforce secret key env

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -8,14 +8,7 @@ from dotenv import load_dotenv  # ✅ تحميل ملف البيئة
 BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(dotenv_path=BASE_DIR / '.env')  # ✅ تحميل ملف .env من جذر المشروع
 
-# ✅ كود فحص مؤقت لتأكيد تحميل متغيرات الاتصال
-print("🔐 DEBUG:", {
-    "DB_NAME": os.environ.get("DJANGO_DB_NAME"),
-    "DB_USER": os.environ.get("DJANGO_DB_USER"),
-    "DB_PASSWORD": os.environ.get("DJANGO_DB_PASSWORD"),
-    "DB_HOST": os.environ.get("DJANGO_DB_HOST"),
-    "DB_PORT": os.environ.get("DJANGO_DB_PORT"),
-})
+# تم إزالة طباعة بيانات الاتصال لتجنب كشف المتغيرات السرية
 
 
 from celery.schedules import crontab
@@ -23,7 +16,9 @@ from django.contrib.messages import constants as message_constants
 from django.utils.translation import gettext_lazy as _
 
 # ── Environment-driven core settings ───────────────────────────────────────────
-SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'secret-for-dev-only')
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+if not SECRET_KEY:
+    raise RuntimeError("DJANGO_SECRET_KEY environment variable is not set")
 DEBUG = os.environ.get('DJANGO_DEBUG', 'True') == 'True'
 
 def _csv_env(name, default=''):


### PR DESCRIPTION
## Summary
- remove temporary database credential printouts in settings
- require `DJANGO_SECRET_KEY` environment variable

## Testing
- `pytest -q` *(fails: tests/test_smoke.py::test_settings_module_and_urls, tests/test_smoke.py::test_user_model_crud)*

------
https://chatgpt.com/codex/tasks/task_e_68adee6dc8788333acc1b4e0374ebee8