### PR TITLE
Enforce authenticated API access

### DIFF
--- a/apps/employees/api_views.py
+++ b/apps/employees/api_views.py
@@ -1,21 +1,29 @@
 # ERP_CORE/employees/api_views.py
 
 from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
 from .models import Employee, AttendanceRecord, MonthlyIncentive
-from .serializers import EmployeeSerializer, AttendanceRecordSerializer, MonthlyIncentiveSerializer
+from .serializers import (
+    EmployeeSerializer,
+    AttendanceRecordSerializer,
+    MonthlyIncentiveSerializer,
+)
 
 class EmployeeViewSet(viewsets.ModelViewSet):
     queryset = Employee.objects.all()
     serializer_class = EmployeeSerializer
+    permission_classes = [IsAuthenticated]
     filterset_fields = ['department', 'gender', 'active']
     search_fields = ['name', 'national_id', 'phone']
 
 class AttendanceRecordViewSet(viewsets.ModelViewSet):
     queryset = AttendanceRecord.objects.all()
     serializer_class = AttendanceRecordSerializer
+    permission_classes = [IsAuthenticated]
     filterset_fields = ['employee', 'date', 'is_absent', 'is_excused_absence']
 
 class MonthlyIncentiveViewSet(viewsets.ModelViewSet):
     queryset = MonthlyIncentive.objects.all()
     serializer_class = MonthlyIncentiveSerializer
+    permission_classes = [IsAuthenticated]
     filterset_fields = ['employee', 'month']

--- a/apps/whatsapp_bot/api_views.py
+++ b/apps/whatsapp_bot/api_views.py
@@ -1,11 +1,13 @@
 # ERP_CORE/whatsapp_bot/api_views.py
 
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from .models import WhatsAppOrder
 from .ai_reply_engine import generate_auto_reply
 
 @api_view(['POST'])
+@permission_classes([AllowAny])
 def receive_whatsapp_message(request):
     sender = request.data.get('sender')
     message = request.data.get('message')

--- a/config/settings.py
+++ b/config/settings.py
@@ -264,6 +264,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',
     ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 20,


### PR DESCRIPTION
## Summary
- require authentication for all DRF APIs
- secure employee API viewsets with IsAuthenticated
- explicitly allow WhatsApp webhook without authentication

## Testing
- `python -m pytest -q` *(fails: `DJANGO_SETTINGS_MODULE` mismatch and `Employee() got unexpected keyword arguments: 'user', 'full_name'`)*

------
https://chatgpt.com/codex/tasks/task_e_68aea98692288333b305fdcdc460a5ca